### PR TITLE
Add controller layer

### DIFF
--- a/cmd/skr/main.go
+++ b/cmd/skr/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/Microsoft/confidential-sidecar-containers/internal/endpointcontroller"
 	"github.com/Microsoft/confidential-sidecar-containers/internal/httpginendpoints"
 	"github.com/Microsoft/confidential-sidecar-containers/pkg/attest"
 	"github.com/Microsoft/confidential-sidecar-containers/pkg/common"
@@ -140,6 +141,12 @@ func setupServer(certState *attest.CertState, identity *common.Identity, uvmInfo
 
 	server := gin.Default()
 	server.Use(httpginendpoints.RegisterGlobalStates(certState, identity, uvmInfo))
+	controllers := endpointcontroller.EndpointController{
+		CertState:      *certState,
+		Identity:       *identity,
+		UvmInformation: *uvmInfo,
+	}
+	server.Use(httpginendpoints.RegisterEndpointController(&controllers))
 	server.GET("/status", httpginendpoints.GetStatus)
 	server.POST("/attest/raw", httpginendpoints.PostRawAttest)
 	server.POST("/attest/maa", httpginendpoints.PostMAAAttest)

--- a/internal/endpointcontroller/README.md
+++ b/internal/endpointcontroller/README.md
@@ -1,0 +1,6 @@
+# Endpoint Controllers
+
+This package provides [controller layer](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html#interface-adapters) for API endpoints of any protocol (http, gRPC, etc.).
+
+We want to provide same endpoints for multiple protocols, but still we want to make them have consistent interface as much as possible.
+By having a rule that we need to use this controller for the same use case, we can reduce the chance to have inconsistent interface for the same use case.

--- a/internal/endpointcontroller/endpointcontroller.go
+++ b/internal/endpointcontroller/endpointcontroller.go
@@ -1,0 +1,55 @@
+package endpointcontroller
+
+import (
+	"encoding/base64"
+
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/attest"
+	"github.com/Microsoft/confidential-sidecar-containers/pkg/common"
+)
+
+type EndpointController struct {
+	CertState      attest.CertState
+	Identity       common.Identity
+	UvmInformation common.UvmInformation
+}
+
+// Status of response
+const (
+	StatusOK           = iota
+	StatusInvalidInput = iota
+	StatusForbidden    = iota
+)
+
+type MAAAttestInput struct {
+	// MAA endpoint which authors the MAA token
+	MAAEndpoint string `json:"maa_endpoint" binding:"required"`
+	// Base64 encoded representation of runtime data to be encoded
+	// as runtime claim in the MAA token
+	RuntimeData string `json:"runtime_data" binding:"required"`
+}
+
+type MAAAttestOutput struct {
+	Token string `json:"token" binding:"required"`
+}
+
+func (c *EndpointController) MAAAttest(input MAAAttestInput) (_ MAAAttestOutput, status uint, _ error) {
+
+	// base64 decode the incoming runtime data
+	runtimeDataBytes, err := base64.StdEncoding.DecodeString(input.RuntimeData)
+	if err != nil {
+		return MAAAttestOutput{}, StatusInvalidInput, err
+	}
+
+	maa := attest.MAA{
+		Endpoint:   input.MAAEndpoint,
+		TEEType:    "SevSnpVM",
+		APIVersion: "api-version=2020-10-01",
+	}
+
+	maaToken, err := c.CertState.Attest(maa, runtimeDataBytes, c.UvmInformation)
+	if err != nil {
+		return MAAAttestOutput{}, StatusForbidden, err
+	}
+
+	return MAAAttestOutput{Token: maaToken}, StatusOK, nil
+}

--- a/internal/grpcendpoints/gprcendpoints.go.pseudo
+++ b/internal/grpcendpoints/gprcendpoints.go.pseudo
@@ -1,0 +1,27 @@
+package grpcendpoints
+
+import (
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// JUST PSEUDO CODE
+// it doesn't work
+
+func MaaAttest(controller *endpointcontroller.EndpointController, in *pb.MaaAttestRequest) (*pb.MaaAttestReply, error) {
+	inputData := endpointcontroller.MAAAttestInput{
+		MAAEndpoint: in.GetMAAEndpoint(),
+		RuntimeData: in.GetRuntimeData()
+	}
+
+	maaToken, status, err := controller.MAAAttest(inputData)
+
+	if err != nil {
+		nil, status.Errorf(convertStatusCode(status), "%s", err)
+	}
+
+	return &pb.MaaAttestReply{Token: maaToken.Token}, nil
+}
+
+func convertStatusCode(...) {...}

--- a/internal/grpcendpoints/protobuf/maa-attest.proto
+++ b/internal/grpcendpoints/protobuf/maa-attest.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package maa_attest;
+
+service MaaAttestService {
+  rpc MaaAttest (MaaAttestRequest) returns (MaaAttestReply) {}
+}
+
+message MaaAttestRequest {
+  string maa_endpoint = 1;
+  string runtime_data = 2;
+}
+
+message MaaAttestReply {
+  string token = 1;
+}


### PR DESCRIPTION
Experimental refactoring for discussion.
Only /attest/maa is changed for now.

Good:
- [Purpose of this PR] You can (almost) force similar interface for multiple protocols (http, gRPC, gRPC + UDS, etc)
- Easier to test (E2E test might be enough though)

Bad:
- Some people might not realize the intention of controller and in that case code can be messy. (Someone might add http specific code to controller even though controller code should be useful regardless of protocol). Once it happens, it's very painful to maintain.